### PR TITLE
Fix readability nits: no "morse code" ligatures, no old-style numerals

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
       --spacing-4xl: 40px;
 
       --font-system: Avenir, Montserrat, Corbel, 'URW Gothic', source-sans-pro, sans-serif;
-      --font-mono: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+      --font-mono: ui-monospace, 'Cascadia Mono', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
       --font-size-sm: 0.9em;
       --font-size-base: 1em;
       --font-size-lg: 1.1em;
@@ -422,6 +422,7 @@
       text-wrap: balance;
       width: 100%;
       min-height: 6rem;
+      font-variant-numeric: lining-nums;
     }
 
     .explanation.correct {


### PR DESCRIPTION
1. Changing 'Cascadia Code' to 'Cascadia Mono' - it is the same thing, just without ligatures; other fonts in the stack (hopefully) have better ligatures, or no ligatures at all. For not to display `.-` as a morse code "a".
2. Changing digits appearance to same height (`lining-nums`) to prevent zero vs `o` confusion, but only in the explanation block.