### PR TITLE
accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,7 +382,7 @@
     }
 
     .option.disabled:not(.correct):not(.incorrect) {
-      opacity: 0.6;
+      opacity: 0.7;
     }
 
     .option-key {

--- a/index.html
+++ b/index.html
@@ -513,7 +513,6 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      transition: all var(--transition-fast);
     }
 
     .copy-button:hover {
@@ -582,7 +581,6 @@
 
     .footer a {
       color: var(--color-primary);
-      transition: color var(--transition-fast);
     }
 
     .footer a:hover {

--- a/index.html
+++ b/index.html
@@ -357,7 +357,6 @@
       border: var(--border-medium) solid var(--color-border);
       border-radius: var(--radius-lg);
       padding: var(--spacing-lg) var(--spacing-xl);
-      cursor: pointer;
       display: flex;
       align-items: center;
       gap: var(--spacing-lg);

--- a/index.html
+++ b/index.html
@@ -405,6 +405,7 @@
 
     .option-text {
       font-family: var(--font-mono);
+      color: var(--color-text-primary);
       flex: 1;
       font-weight: bold;
       pointer-events: none;
@@ -1357,9 +1358,9 @@
       optionsContainer.innerHTML = '';
 
       question.options.forEach((option, index) => {
-        const optionDiv = document.createElement('div');
-        optionDiv.className = 'option';
-        optionDiv.onclick = () => selectOption(index);
+        const button = document.createElement('button');
+        button.className = 'option';
+        button.onclick = () => selectOption(index);
 
         const keyDiv = document.createElement('div');
         keyDiv.className = 'option-key';
@@ -1369,9 +1370,9 @@
         textDiv.className = 'option-text';
         textDiv.textContent = option;
 
-        optionDiv.appendChild(keyDiv);
-        optionDiv.appendChild(textDiv);
-        optionsContainer.appendChild(optionDiv);
+        button.appendChild(keyDiv);
+        button.appendChild(textDiv);
+        optionsContainer.appendChild(button);
       });
 
       const explanation = document.getElementById('explanation');

--- a/index.html
+++ b/index.html
@@ -742,7 +742,7 @@
     </svg>
   </button>
 
-  <div class="container">
+  <div class="container" aria-live="polite">
     <div id="startScreen" class="start-screen">
       <div class="start-content">
         <header>

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
       --color-secondary: var(--slightly-lighter-wong-blue);
       --color-secondary-hover: #004A7A;
 
-      --color-bg-dark: var(--white);
+      --color-bg-dark: var(--grey-900);
       --color-bg-medium: #F7F7F7;
       --color-bg-light: var(--gray-100);
       --color-bg-lighter: var(--gray-200);

--- a/index.html
+++ b/index.html
@@ -582,7 +582,6 @@
 
     .footer a {
       color: var(--color-primary);
-      text-decoration: none;
       transition: color var(--transition-fast);
     }
 

--- a/index.html
+++ b/index.html
@@ -1366,12 +1366,12 @@
         keyDiv.className = 'option-key';
         keyDiv.textContent = (index + 1).toString();
 
-        const textDiv = document.createElement('div');
-        textDiv.className = 'option-text';
-        textDiv.textContent = option;
+        const text = document.createElement('span');
+        text.className = 'option-text';
+        text.textContent = option;
 
         button.appendChild(keyDiv);
-        button.appendChild(textDiv);
+        button.appendChild(text);
         optionsContainer.appendChild(button);
       });
 

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
       --wong-bluish-green: #009E73;
       --wong-yellow: #F0E442;
       --wong-blue: #0072B2;
+      --slightly-lighter-wong-blue: #0081CC;
       --wong-blue-dark: #005A8F;
       --wong-vermillion: #D55E00;
       --wong-red-purple: #CC79A7;
@@ -51,7 +52,7 @@
     :root {
       --color-primary: var(--wong-orange);
       --color-primary-hover: var(--wong-orange-dark);
-      --color-secondary: var(--wong-blue);
+      --color-secondary: var(--slightly-lighter-wong-blue);
       --color-secondary-hover: var(--wong-blue-dark);
 
       --color-bg-dark: var(--gray-900);
@@ -119,7 +120,7 @@
     [data-theme="light"] {
       --color-primary: var(--wong-orange-dark);
       --color-primary-hover: #B36A00;
-      --color-secondary: var(--wong-blue-dark);
+      --color-secondary: var(--slightly-lighter-wong-blue);
       --color-secondary-hover: #004A7A;
 
       --color-bg-dark: var(--white);

--- a/index.html
+++ b/index.html
@@ -404,6 +404,7 @@
       border-radius: inherit;
       display: flex;
       align-items: center;
+      width: 100%;
       padding: var(--spacing-lg) var(--spacing-xl);
       font-family: var(--font-mono);
       color: var(--color-text-primary);
@@ -411,7 +412,7 @@
       background-color: transparent;
       border: none;
       font-size: var(--font-size-base);
-      text-align: center;
+      text-align: left;
     }
 
     .option-text {

--- a/index.html
+++ b/index.html
@@ -408,7 +408,7 @@
       font-family: var(--font-mono);
       color: var(--color-text-primary);
       gap: var(--spacing-lg);
-      background-color: inherit;
+      background-color: transparent;
       border: none;
       font-size: var(--font-size-base);
       text-align: center;

--- a/index.html
+++ b/index.html
@@ -397,13 +397,13 @@
       font-weight: bold;
       flex-shrink: 0;
       font-size: var(--font-size-base);
+      font-family: var(--font-system);
     }
 
     .option-button {
-      flex: 1;
+      border-radius: inherit;
       display: flex;
       align-items: center;
-      justify-content: center;
       padding: var(--spacing-lg) var(--spacing-xl);
       font-family: var(--font-mono);
       color: var(--color-text-primary);

--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
       --color-bg-lighter: var(--gray-200);
 
       --color-text-primary: var(--gray-800);
-      --color-text-secondary: var(--gray-400);
+      --color-text-secondary: var(--gray-500);
 
       --color-border: var(--gray-200);
       --color-border-hover: var(--gray-300);

--- a/index.html
+++ b/index.html
@@ -356,11 +356,8 @@
       background-color: var(--color-bg-light);
       border: var(--border-medium) solid var(--color-border);
       border-radius: var(--radius-lg);
-      padding: var(--spacing-lg) var(--spacing-xl);
       display: flex;
       align-items: center;
-      gap: var(--spacing-lg);
-      font-size: var(--font-size-base);
     }
 
     .option:hover:not(.disabled) {
@@ -399,15 +396,27 @@
       font-weight: bold;
       flex-shrink: 0;
       font-size: var(--font-size-base);
-      pointer-events: none;
+    }
+
+    .option-button {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: var(--spacing-lg) var(--spacing-xl);
+      font-family: var(--font-mono);
+      color: var(--color-text-primary);
+      gap: var(--spacing-lg);
+      background-color: inherit;
+      border: none;
+      font-size: var(--font-size-base);
+      text-align: center;
     }
 
     .option-text {
-      font-family: var(--font-mono);
       color: var(--color-text-primary);
       flex: 1;
       font-weight: bold;
-      pointer-events: none;
     }
 
     .explanation {
@@ -447,7 +456,6 @@
       padding: var(--spacing-lg) var(--spacing-3xl);
       font-size: var(--font-size-lg);
       font-weight: bold;
-      cursor: pointer;
       max-width: 250px;
       width: 100%;
     }
@@ -592,6 +600,10 @@
       font-style: italic;
     }
 
+    li {
+      list-style: none;
+    }
+
     @media (max-width: 600px) {
       body {
         padding: var(--spacing-sm);
@@ -625,8 +637,11 @@
       }
 
       .option {
-        padding: var(--spacing-md) var(--spacing-lg);
         font-size: var(--font-size-sm);
+      }
+
+      .option-button {
+        padding: var(--spacing-md) var(--spacing-lg);
       }
 
       .option-key {
@@ -773,7 +788,7 @@
       </div>
       <div class="explanation" id="explanation"></div>
 
-      <div class="options" id="options"></div>
+      <ul class="options" id="options"></ul>
 
       <button id="nextButton" class="button hidden" onclick="nextQuestion()">Next Question</button>
     </div>
@@ -1357,21 +1372,26 @@
       optionsContainer.innerHTML = '';
 
       question.options.forEach((option, index) => {
-        const button = document.createElement('button');
-        button.className = 'option';
-        button.onclick = () => selectOption(index);
-
-        const keyDiv = document.createElement('div');
-        keyDiv.className = 'option-key';
-        keyDiv.textContent = (index + 1).toString();
-
         const text = document.createElement('span');
         text.className = 'option-text';
         text.textContent = option;
 
-        button.appendChild(keyDiv);
+        const key = document.createElement('span');
+        key.className = 'option-key';
+        key.textContent = (index + 1).toString();
+
+        const button = document.createElement('button');
+        button.className = 'option-button';
+        button.onclick = () => selectOption(index);
+
+        button.appendChild(key);
         button.appendChild(text);
-        optionsContainer.appendChild(button);
+
+        const li = document.createElement('li');
+        li.className = 'option';
+        li.appendChild(button);
+
+        optionsContainer.appendChild(li);
       });
 
       const explanation = document.getElementById('explanation');


### PR DESCRIPTION
Resolves some accessibility issues, namely

- quiz options are now focusable and can be interacted with via the keyboard
- uses more semantic elements, like `span` and `button` instead of `div`
- wraps quiz options in an unordered list
- use aria-live to notify screen readers when the the quiz advances, see [the below screenshots](##screenshost)
- increase contrast in share button, disabled buttons, and next button
- add text decoration to links so that they are distinguishable even without color

Also does the following cleanup
- remove unset variable

## screenshots
If not listed, it looks the same

| Description | Before| After|
|--------|--------|--------|
| increased text contrast on light mode landing page. The grey text is darkened to contrast against the light grey background and the button text is changed to black to contrast against the yellow | <img width="1663" height="1011" alt="" src="https://github.com/user-attachments/assets/87945c3f-b6cb-418d-a6ec-608a68ecf32b" />| <img width="1663" height="1011" alt="" src="https://github.com/user-attachments/assets/fdec3953-725f-409c-8345-37027e28214e" />|
| Questions dark mode has increased opacity on disabled options | <img width="1676" height="1011" alt="" src="https://github.com/user-attachments/assets/af063782-b514-4ae8-865c-c2103eb85e55" /> | <img width="1676" height="1011" alt="image" src="https://github.com/user-attachments/assets/a5d706d9-9135-4fa0-8083-33f603af2b88" /> |
| Questions light mode has black text on the yellow next button and increased opacity on disabled options | <img width="1676" height="1011" alt="" src="https://github.com/user-attachments/assets/252defbf-2186-43aa-8d6e-eafa48acd7e0" />| <img width="1676" height="1011" alt="" src="https://github.com/user-attachments/assets/eb0c6414-a812-4ee4-a153-8a6a925cf361" />| 
| Dark mode results screen. Share button has lighter blue color and uses white color text. Also note the existing but where the "You got to the end!" is off the screen 😅 | <img width="1676" height="1011" alt="" src="https://github.com/user-attachments/assets/f37673ff-3d8f-41d5-9635-f7e637951dc5" />| <img width="1676" height="1011" alt="image" src="https://github.com/user-attachments/assets/0e738c6e-a9da-4298-82dc-f9053878f5a8" />|
| Light mode results screen. Share button color is lighter and copyable text is darker | <img width="1676" height="1011" alt="image" src="https://github.com/user-attachments/assets/2dcc89b6-31aa-4010-b794-6c96046aa98a" /> | <img width="1676" height="1011" alt="image" src="https://github.com/user-attachments/assets/3f7f1af0-1230-4944-b725-5bb77189bdf6" />|
| Toast uses black on yellow instead of white on yellow | <img width="445" height="210" alt="" src="https://github.com/user-attachments/assets/acb8eb1f-798d-4513-b155-512a3f8b28e5" /> | <img width="435" height="214" alt="" src="https://github.com/user-attachments/assets/92f83bce-330f-4fd9-a5ca-b59265e960b0" />|

## closing notes
I didn't fix everything I saw, but this is a big step in the right direction :)
- there are likely still contrast issues lurking
- the incorrect and correct buttons do not describe themselves as such beyond color
- I suspect the toast when sharing is not accessible
